### PR TITLE
End-to-end test scripts

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -856,6 +856,7 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190128161407-8ac453e89fca/go.mod h1:L3J43x8/uS+qIUoksaLKe6OS3nUKxOKuIFz1sl2/jx4=

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,3 @@
+.PHONY: fsmanage
+fsmanage:
+	go build -o $(TESTDIR)/fsmanage ./pkg/aws/...

--- a/test/cleanup.sh
+++ b/test/cleanup.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+source ${0%/*}/lib.sh
+
+err() {
+  echo "$@" >&2
+  exit 1
+}
+
+declare -A CLEAN
+CLEAN=(
+  [pods]=0
+  [sharedvolumes]=0
+  [efs]=0
+  [operator]=0
+)
+
+if [ -z $1 ]; then
+  err "Specify at least one thing to clean up, or 'all'.
+    ${!CLEAN[@]}"
+  exit 1
+fi
+
+while [ "$1" ]; do
+  if [[ "$1" == "all" ]]; then
+    # Switch on everything
+    for k in "${!CLEAN[@]}"; do
+      CLEAN[$k]=1
+    done
+    # Ignore anything else
+    break
+  fi
+
+  if ! [[ " ${!CLEAN[@]} " == *" $1 "* ]]; then
+    err "Unknown cleanup target '$1'. Specify 'all', or at least one of
+      ${!CLEAN[@]}"
+  fi
+  CLEAN[$1]=1
+  shift
+done
+
+toclean=
+for k in "${!CLEAN[@]}"; do
+  if [[ ${CLEAN[$k]} -eq 1 ]]; then
+    toclean="$toclean $k"
+  fi
+done
+echo
+echo "==========="
+echo "Will clean:
+  $toclean"
+echo "==========="
+
+### Pods first
+if [[ ${CLEAN[pods]} -eq 1 ]]; then
+  echo
+  echo "Cleaning up pods..."
+  echo "==================="
+  for ns in "${WORK_NAMESPACES[@]}"; do
+    echo "Deleting pods from namespace $ns"
+    oc delete pods -n $ns --all &
+  done
+  wait
+fi
+
+### Then SVs
+if [[ ${CLEAN[sharedvolumes]} -eq 1 ]]; then
+  echo
+  echo "Cleaning up sharedvolumes..."
+  echo "============================"
+  for ns in "${WORK_NAMESPACES[@]}"; do
+    echo "Deleting SharedVolumes from namespace $ns"
+    oc delete sharedvolumes -n $ns --all &
+  done
+  wait
+fi
+
+### Then the operator
+if [[ ${CLEAN[operator]} -eq 1 ]]; then
+  echo
+  echo "Uninstalling operator..."
+  echo "========================"
+  if ! oc get project $OPERATOR_NAMESPACE; then
+    echo "Assuming the operator is already gone"
+  else
+    oc project $OPERATOR_NAMESPACE
+    # Uninstall the operator before blowing away the CRD
+    /bin/ls $DEPLOYDIR/*.yaml | xargs -n1 oc delete -f
+    # Today, uninstalling the operator doesn't clean up statics
+    $REPO_ROOT/hack/scripts/delete_statics.sh
+    oc project default
+    oc delete namespace $OPERATOR_NAMESPACE
+    # This will break if there's more than one *_crd.yaml
+    oc delete -f $DEPLOYDIR/crds/*_crd.yaml
+  fi
+fi
+
+### Finally EFS stuff
+if [[ ${CLEAN[efs]} -eq 1 ]]; then
+  echo
+  echo "Cleaning up EFS..."
+  echo "=================="
+  ${TESTDIR}/fsmanage --delete-all
+fi

--- a/test/driver.sh
+++ b/test/driver.sh
@@ -1,0 +1,122 @@
+#!/bin/bash -e
+
+source ${0%/*}/lib.sh
+
+FSSPEC=${TESTDIR}/fsspec.yaml
+
+TMPD=$(mktemp -d)
+trap "rm -fr $TMPD" EXIT
+
+echo
+echo "=============================================="
+echo "THIS TOOL DOES NOT REBUILD THE OPERATOR IMAGE!"
+echo "You have to do that yourself."
+echo "I'm going to use $OPERATOR_IMAGE"
+echo "=============================================="
+
+ensure_fs_state
+
+ensure_operator
+
+ensure_namespaces
+
+echo
+echo "Discovering file systems and access points"
+echo "=========================================="
+fsinfo="$(${TESTDIR}/fsmanage --discover)"
+
+echo
+echo "Creating SharedVolume resources"
+echo "==============================="
+pids=
+for fsap in $fsinfo; do
+  fsid=${fsap%:*}
+  apid=${fsap#*:}
+  echo "=> FS $fsid  AP $apid"
+  for ns in ${WORK_NAMESPACES[@]}; do
+    echo "===> Namespace: $ns"
+    create_shared_volume $ns $fsid $apid &
+    pids="$pids $!"
+  done
+done
+for pid in $pids; do wait $pid; done
+
+echo
+echo "Creating test pods"
+echo "=================="
+# We need to build up the lists that will go in the pod defs under
+# .spec.volumes and .spec.containers[0].volumeMounts.
+for fsap in $fsinfo; do
+  fsid=${fsap%:*}
+  apid=${fsap#*:}
+  slug=$(slugify $fsid $apid)
+  cat <<EOF >>$TMPD/volumes
+  - name: efs-$slug
+    persistentVolumeClaim:
+      claimName: pvc-sv-$slug
+EOF
+  cat <<EOF >>$TMPD/mounts
+    - mountPath: /mnt/efs-$slug
+      name: efs-$slug
+EOF
+done
+VOLUMES="$(cat $TMPD/volumes)"
+MOUNTS="$(cat $TMPD/mounts)"
+
+pids=
+for ns in ${WORK_NAMESPACES[@]}; do
+  echo "=> Namespace: $ns"
+  create_test_pod $ns "$VOLUMES" "$MOUNTS" &
+  pids="$pids $!"
+done
+for pid in $pids; do wait $pid; done
+
+echo
+echo "Writing..."
+echo "=========="
+for ns in ${WORK_NAMESPACES[@]}; do
+  echo "=> Namespace: $ns"
+  for fsap in $fsinfo; do
+    fsid=${fsap%:*}
+    apid=${fsap#*:}
+    slug=$(slugify $fsid $apid)
+    # Suffix with the current PID so the test is repeatable (we don't
+    # keep growing the same file)
+    path=/mnt/efs-$slug/data.$$
+    message="$ns was here in $slug"
+    echo "===> Path: $path"
+    oc rsh -n $ns pod/efs-pod bash -c "echo '$message' >> $path"
+    # NOTE: append
+    echo "$message" >> $TMPD/expected.$slug
+  done
+done
+
+echo
+echo "Reading..."
+echo "=========="
+for ns in ${WORK_NAMESPACES[@]}; do
+  echo "=> Namespace: $ns"
+  for fsap in $fsinfo; do
+    fsid=${fsap%:*}
+    apid=${fsap#*:}
+    slug=$(slugify $fsid $apid)
+    path=/mnt/efs-$slug/data.$$
+    echo "===> Path: $path"
+    # NOTE: overwrite, and check each time
+    oc rsh -n $ns pod/efs-pod bash -c "cat $path" > $TMPD/actual.$slug
+    # TODO(efried): `actual` is coming back with Windows-style
+    # newlines!! WTAF??
+    if ! diff -w $TMPD/expected.$slug $TMPD/actual.$slug; then
+      echo EXPECTED
+      od -c $TMPD/expected.$slug
+      echo ACTUAL
+      od -c $TMPD/actual.$slug
+      exit -1
+    fi
+  done
+done
+
+echo
+echo "==================================="
+echo "If you got here, everything worked!"
+echo "==================================="

--- a/test/fsspec.yaml
+++ b/test/fsspec.yaml
@@ -1,0 +1,8 @@
+fs1:
+    - apX
+fs2:
+    - apY
+fs3:
+    - ap3_1
+    - ap3_2
+    - ap3_3

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -1,0 +1,154 @@
+REPO_ROOT=$(git rev-parse --show-toplevel)
+export TESTDIR="${REPO_ROOT}/test"
+DEPLOYDIR="${REPO_ROOT}/deploy"
+OPERATOR_NAMESPACE=test-openshift-aws-efs
+WORK_NAMESPACES=(myns1 myns2)
+
+# TODO(efried): This isn't very nice for consumers who aren't me.
+if [ -z "$IMAGE_REPOSITORY" ]; then
+  export IMAGE_REPOSITORY=2uasimojo
+fi
+if [ -z "$OPERATOR_TAG" ]; then
+  OPERATOR_TAG=latest
+fi
+
+OPERATOR_IMAGE=quay.io/${IMAGE_REPOSITORY}/aws-efs-operator:${OPERATOR_TAG}
+
+awscreds() {
+  export AWS_DEFAULT_REGION=us-east-1
+  SECRETS=$(oc get secrets -n kube-system aws-creds -o json)
+  export AWS_ACCESS_KEY_ID=$(echo "$SECRETS" | jq -r .data.aws_access_key_id | base64 -d)
+  export AWS_SECRET_ACCESS_KEY=$(echo "$SECRETS" | jq -r .data.aws_secret_access_key | base64 -d)
+}
+
+
+err() {
+  echo "$@" >&2
+  exit 1
+}
+
+slugify() {
+  local fsid=$1
+  local apid=$2
+  echo "${fsid#*-}-${apid#*-}"
+}
+
+create_shared_volume() {
+  local ns=$1
+  local fsid=$2
+  local apid=$3
+  local svname=sv-$(slugify $fsid $apid)
+  local spec=$TMPD/$ns-$svname.yaml
+  cat <<EOF>$spec
+apiVersion: aws-efs.managed.openshift.io/v1alpha1
+kind: SharedVolume
+metadata:
+  name: $svname
+  namespace: $ns
+spec:
+  accessPointID: $apid
+  fileSystemID: $fsid
+EOF
+  oc apply -f $spec
+
+  echo "Waiting for sv/$svname in namespace $ns to have Ready status"
+  while [[ $(oc get sv/$svname -n $ns -o jsonpath={.status.phase}) != Ready ]]; do
+    sleep 1
+  done
+
+  echo "Waiting for pvc/pvc-$svname in namespace $ns to be Bound"
+  while [[ $(oc get pvc/pvc-$svname -n $ns -o jsonpath={.status.phase}) != Bound ]]; do
+    sleep 1
+  done
+}
+
+create_test_pod() {
+  local ns=$1
+  local volumes="$2"
+  local mounts="$3"
+  local spec=$TMPD/pod-$ns.yaml
+  cat <<EOF>$spec
+apiVersion: v1
+kind: Pod
+metadata:
+  name: efs-pod
+  namespace: $ns
+spec:
+  volumes:
+${volumes}
+  containers:
+  - name: efs-container
+    image: centos:latest
+    command: [ "/bin/bash", "-c", "--" ]
+    args: [ "while true; do sleep 30; done" ]
+    volumeMounts:
+${mounts}
+EOF
+  oc apply -f $spec
+
+  echo "Waiting for the Pod in namespace $ns to be Running"
+  while [[ $(oc get pod/efs-pod -n $ns -o jsonpath={.status.phase}) != Running ]]; do
+    sleep 1
+  done
+
+  echo "Waiting for the container in namespace $ns to be started"
+  while [[ $(oc get pod/efs-pod -n $ns -o jsonpath={.status.containerStatuses[0].started}) != 'true' ]]; do
+    sleep 1
+  done
+}
+
+ensure_fs_state() {
+  echo
+  echo "Ensuring file system state"
+  echo "=========================="
+  awscreds
+  ${TESTDIR}/fsmanage --spec ${TESTDIR}/fsspec.yaml
+}
+
+ensure_operator() {
+  echo
+  echo "Installing operator..."
+  echo "======================"
+  echo "=> Ensuring operator namespace $OPERATOR_NAMESPACE"
+  oc get namespace $OPERATOR_NAMESPACE || oc create namespace $OPERATOR_NAMESPACE
+  oc project $OPERATOR_NAMESPACE
+  echo "=> Applying CRD"
+  # This will break if there's more than one *_crd.yaml.
+  oc apply -f $DEPLOYDIR/crds/*_crd.yaml
+  echo "=> Deploying operator stuffs"
+  # These `sed`s are because:
+  # - We need to set the image name in the operator deployment.
+  # - Due to webhooks denying use of `openshift-*`, we have to hack the
+  #   operator namespace :(
+  #   This relies on that namespace only being set where we expect it (the
+  #   ServiceAccount subject in the ClusterRoleBinding). If it's set
+  #   anywhere else, and needs to be something other than the operator
+  #   namespace, this will break.
+  pids=
+  for f in $(/bin/ls $DEPLOYDIR/*.yaml); do
+    spec=$TMPD/$(basename $f)
+    sed "s/namespace: .*/namespace: $OPERATOR_NAMESPACE/; s,REPLACE_IMAGE,$OPERATOR_IMAGE," $f > $spec
+    oc apply -f $spec &
+    pids="$pids $!"
+  done
+  for pid in $pids; do wait $pid; done
+}
+
+ensure_namespaces() {
+  echo
+  echo "Ensuring work namespaces..."
+  echo "==========================="
+  pids=
+  for ns in ${WORK_NAMESPACES[@]}; do
+    oc get namespace $ns || oc create namespace $ns &
+    pids="$pids $!"
+  done
+  for pid in $pids; do wait $pid; done
+}
+
+############################################
+echo
+echo "Building fsmanage"
+echo "================="
+# No-op if already built, because make
+make -f ${TESTDIR}/Makefile fsmanage


### PR DESCRIPTION
This adds a `test/driver.sh` that:
- Syncs file system state based on a spec file (`test/fsspec.yaml`).
- Installs the aws-efs-operator in the current cluster.
- Creates SharedVolume CRs for each access point in each of two
namespaces.
- Creates a pod in each namespace that mounts all of the resulting PVs.
- Writes to a data file in each mounted directory via each pod.
- Reads back the files from each directory from each pod and verifies
that all expected data was written.

...and a `test/cleanup.sh` that deletes all the above things.

These are idempotent and asynchronous as much as possible, but it's not
perfect. For example, if you run `driver.sh` multiple times without
cleaning up, the data files grow (which is good behavior) but the test
is only expecting one iteration's worth of data at the moment.