### PR TITLE
Make PV/PVC owned by SharedVolume

### DIFF
--- a/pkg/apis/awsefs/v1alpha1/owner.go
+++ b/pkg/apis/awsefs/v1alpha1/owner.go
@@ -1,0 +1,16 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateOwnerReference constructs an OwnerReference from this SharedVolume, for use in the list of
+// OwnerReferences of another object.
+func (sv *SharedVolume) CreateOwnerReference() metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: sv.APIVersion,
+		Kind:       sv.Kind,
+		Name:       sv.Name,
+		UID:        sv.UID,
+	}
+}

--- a/pkg/controller/sharedvolume/pv_ensurable.go
+++ b/pkg/controller/sharedvolume/pv_ensurable.go
@@ -55,6 +55,10 @@ func pvDefinition(sharedVolume *awsefsv1alpha1.SharedVolume) *corev1.PersistentV
 	pv := &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: pvNameForSharedVolume(sharedVolume),
+			// Make the PV owned by the SV so it gets deleted automatically
+			OwnerReferences: []metav1.OwnerReference{
+				sharedVolume.CreateOwnerReference(),
+			},
 		},
 		Spec: corev1.PersistentVolumeSpec{
 			Capacity: corev1.ResourceList{

--- a/pkg/controller/sharedvolume/pvc_ensurable.go
+++ b/pkg/controller/sharedvolume/pvc_ensurable.go
@@ -57,6 +57,10 @@ func pvcDefinition(sharedVolume *awsefsv1alpha1.SharedVolume) *corev1.Persistent
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nsname.Name,
 			Namespace: nsname.Namespace,
+			// Make the PVC owned by the SV so it gets deleted automatically
+			OwnerReferences: []metav1.OwnerReference{
+				sharedVolume.CreateOwnerReference(),
+			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},

--- a/pkg/controller/sharedvolume/testdata/persistentvolume.yaml
+++ b/pkg/controller/sharedvolume/testdata/persistentvolume.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: pv-project1-my-shared-volume
+  ownerReferences:
+    - name: my-shared-volume
 spec:
   capacity:
     storage: 1Gi

--- a/pkg/controller/sharedvolume/testdata/pvc.yaml
+++ b/pkg/controller/sharedvolume/testdata/pvc.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-my-shared-volume
   namespace: project1
+  ownerReferences:
+    - name: my-shared-volume
 spec:
   accessModes:
     - ReadWriteMany


### PR DESCRIPTION
By adding an OwnerReference to the SharedVolume to the PV and PVC it
creates, kubernetes handles their deletion for us. This allows us to rip
out a big chain of code, including:

- Deletion logic for PV and PVC Ensurables.
- The entire SharedVolume finalizer and associated handling, since the
above was its only purpose.